### PR TITLE
Update MandrillServiceProvider.php

### DIFF
--- a/src/MandrillServiceProvider.php
+++ b/src/MandrillServiceProvider.php
@@ -13,7 +13,7 @@ class MandrillServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app['swift.transport']->extend('mandrill', function () {
+        $this->app('mailer')->getSwiftMailer()->extend('mandrill', function () {
             return TransportFactory::mandrill(
                 $this->app['config']->get('services.mandrill', [])
             );

--- a/src/MandrillServiceProvider.php
+++ b/src/MandrillServiceProvider.php
@@ -13,7 +13,7 @@ class MandrillServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app('mailer')->getSwiftMailer()->extend('mandrill', function () {
+        app('mailer')->getSwiftMailer()->extend('mandrill', function () {
             return TransportFactory::mandrill(
                 $this->app['config']->get('services.mandrill', [])
             );

--- a/tests/MandrillServiceProviderTest.php
+++ b/tests/MandrillServiceProviderTest.php
@@ -9,7 +9,7 @@ class MandrillServiceProviderTest extends TestCase
     /** @test */
     public function it_extends_the_mail_manager_with_mandrill_driver()
     {
-        $driver = $this->app['swift.transport']->driver('mandrill');
+        $driver = $this->app('mailer')->getSwiftMailer()->driver('mandrill');
 
         $this->assertInstanceOf(MandrillTransport::class, $driver);
     }

--- a/tests/MandrillServiceProviderTest.php
+++ b/tests/MandrillServiceProviderTest.php
@@ -9,7 +9,7 @@ class MandrillServiceProviderTest extends TestCase
     /** @test */
     public function it_extends_the_mail_manager_with_mandrill_driver()
     {
-        $driver = $this->app('mailer')->getSwiftMailer()->driver('mandrill');
+        $driver = app('mailer')->getSwiftMailer()->driver('mandrill');
 
         $this->assertInstanceOf(MandrillTransport::class, $driver);
     }


### PR DESCRIPTION
Laravel 7.x doesn't provide swift.mailer and swift.transport container bindings. You may now access these objects through the mailer binding:

$swiftMailer = app('mailer')->getSwiftMailer();

$swiftTransport = $swiftMailer->getTransport();